### PR TITLE
fix plugin id to use lower camel casing

### DIFF
--- a/packages/stash-plugin-builder/src/script.ts
+++ b/packages/stash-plugin-builder/src/script.ts
@@ -6,7 +6,7 @@ import Shared from "./shared/shared"
 import buildPlugin from "./builder/plugin"
 import getSettingsYml from "./helpers/settingsYml"
 import getEsbuildOptions from "./helpers/esbuidConfig"
-import { isUpperCamelCase } from "./utils/utils"
+import { isLowerCamelCase } from "./utils/utils"
 import { createFolder, unixPath, getRootPath } from "./utils/glob"
 
 configDotenv({
@@ -23,8 +23,8 @@ export default async function build() {
     Shared.settings.ui.javascript = unixPath(Shared.args.mainJsPath ?? Shared.settings.ui.javascript ?? "")
     Shared.settings.ui.css = unixPath(Shared.args.mainCssPath ?? Shared.settings.ui.css ?? "")
 
-    if (!isUpperCamelCase(Shared.settings.id)) {
-        console.log(chalk.red("settings.yml: 'id' value should be upper camel case. eg: 'MyStashPlugin'"))
+    if (!isLowerCamelCase(Shared.settings.id)) {
+        console.log(chalk.red("settings.yml: 'id' value should be lower camel case. eg: 'myStashPlugin'"))
         process.exit()
     } else if (!Shared.settings.version) {
         console.log(chalk.red("settings.yml: version info is missing"))

--- a/packages/stash-plugin-builder/src/utils/utils.ts
+++ b/packages/stash-plugin-builder/src/utils/utils.ts
@@ -4,6 +4,10 @@ export function isUpperCamelCase(str: string): boolean {
     return /^[A-Z][a-zA-Z0-9]*$/.test(str)
 }
 
+export function isLowerCamelCase(str: string): boolean {
+    return /^[a-z][a-zA-Z0-9]*$/.test(str)
+}
+
 export function replaceContent(content: string, values: string[]): string {
     values.forEach((value, index) => {
         content = content.replace(new RegExp(`\\$replace${index + 1}`, "g"), value)


### PR DESCRIPTION
Plugin IDs should be lower camel cased otherwise Stash will not display your plugin setting values on the plugins page.

To demonstrate the issue, you can try creating a plugin with an upper camelcased name `TestPlugin.yml` with the following config
```name: Test Plugin
description: My plugin does awesome things
version: 1.0
settings:
  test:
    displayName: Test
    type: STRING
```

If you load this plugin and give the setting a value, you'll see it:
![image](https://github.com/Tetrax-10/stash-plugin-builder/assets/38586902/489cb459-df37-4905-89f5-df0d3935b662)
The issue appears when you refresh the page. The test value disappears:
![image](https://github.com/Tetrax-10/stash-plugin-builder/assets/38586902/35174758-8bec-4b5b-8489-e02396498fd2)
However, the value is still in the stash `config.yml`, so it still exists.

So if you rename the plugin id to `testPlugin.yml` and reload it, then the value comes back:
![image](https://github.com/Tetrax-10/stash-plugin-builder/assets/38586902/e534334d-3124-4a1b-b9c3-04259cd1452b)